### PR TITLE
Fix UNIX builds, add build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,14 @@ __pycache__/
 *.cue
 *.iso
 
+# Build artifacts
+build/
+debug/
+*.log
+offset.txt
+overlay.ld
+Makefile
+
 # Third party stuff
 tools/gcc-psyq-converted/include/*
 tools/gcc-psyq-converted/lib/*

--- a/samples/common.mk
+++ b/samples/common.mk
@@ -1,3 +1,11 @@
+ifeq ($(OS),Windows_NT)
+  PYTHON = python
+else ifeq ($(shell which python3),)
+  PYTHON = python
+else
+  PYTHON = python3
+endif
+
 THISDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLSDIR = $(THISDIR)../tools/
 

--- a/tools/mod-builder/makefile.py
+++ b/tools/mod-builder/makefile.py
@@ -4,6 +4,7 @@ from common import create_directory, FOLDER_DISTANCE, DEBUG_FOLDER, OUTPUT_FOLDE
 import re
 import json
 import os
+import shutil
 
 class Makefile:
     def __init__(self, build_id: int, sym_file: list[str]) -> None:
@@ -124,8 +125,8 @@ class Makefile:
         create_directory(BACKUP_FOLDER)
         create_directory(DEBUG_FOLDER)
         os.system("make -s -j8")
-        os.system("move mod.map " + DEBUG_FOLDER)
-        os.system("move mod.elf " + DEBUG_FOLDER)
+        shutil.move("mod.map", DEBUG_FOLDER + "mod.map")
+        shutil.move("mod.elf", DEBUG_FOLDER + "mod.elf")
 
         if not os.path.isfile(GCC_MAP_FILE):
             print("\n[Makefile-py] ERROR: compilation was not successful.\n")

--- a/tools/nugget/common.mk
+++ b/tools/nugget/common.mk
@@ -44,7 +44,7 @@ all: dep $(foreach ovl, $(OVERLAYSECTION), $(BINDIR)Overlay$(ovl))
 
 $(BINDIR)Overlay%: $(BINDIR)$(TARGET).elf
 	$(PREFIX)-objcopy -j $(@:$(BINDIR)Overlay%=%) -O binary $< $(BINDIR)$(TARGET)$(@:$(BINDIR)Overlay%=%)
-	python $(TOOLSDIR)trimbin/trimbin.py $(BINDIR)$(TARGET)$(@:$(BINDIR)Overlay%=%) $(BUILDDIR)
+	$(PYTHON) $(TOOLSDIR)trimbin/trimbin.py $(BINDIR)$(TARGET)$(@:$(BINDIR)Overlay%=%) $(BUILDDIR)
 
 $(BINDIR)$(TARGET).elf: $(OBJS)
 ifneq ($(strip $(BINDIR)),)


### PR DESCRIPTION
1. makefile.py was using "move", a platform-specific Windows command. I replaced this with move from the shutil library, which is platform-agnostic.

2. On MacOS and other UNIX systems, python versions >= 3.0 are installed as "python3" instead of "python". I added checks for this so python3 works.

3. I added build artifacts from compiling/building the ISO to .gitignore.