### PR TITLE
add command line arg support

### DIFF
--- a/tools/mod-builder/common.py
+++ b/tools/mod-builder/common.py
@@ -71,10 +71,15 @@ def create_directory(dirname: str) -> None:
         os.mkdir(dirname)
 
 def request_user_input(first_option: int, last_option: int, error_msg: str) -> int:
+    if len(sys.argv) > 1 and len(remaining_args) == 0:
+        incomplete_args_msg = "ERROR: Not enough arguments to complete command."
+        print(incomplete_args_msg)
+        raise Exception(incomplete_args_msg)
+
     i = 0
     while True:
         try:
-            i = int(input()) if len(sys.argv) < 2 or len(remaining_args) == 0 else int(remaining_args.pop(0))
+            i = int(input()) if len(sys.argv) < 2 else int(remaining_args.pop(0))
             if (i < first_option) or (i > last_option):
                 print(error_msg)
                 if (sys.argv > 1):

--- a/tools/mod-builder/common.py
+++ b/tools/mod-builder/common.py
@@ -1,10 +1,17 @@
 import os
+import sys
+import copy
+
+remaining_args = copy.deepcopy(sys.argv[1:])
 
 CONFIG_FILE = "config.json"
 
 def cli_pause() -> None:
-    print("Press enter to continue...")
-    input()
+    if len(sys.argv) > 1:
+        sys.exit(0) if len(remaining_args) == 0 else print("Continuing...")
+    else:
+        print("Press Enter to continue...")
+        input()
 
 def get_distance_to_config(print_error: bool) -> str:
     if print_error:
@@ -67,13 +74,17 @@ def request_user_input(first_option: int, last_option: int, error_msg: str) -> i
     i = 0
     while True:
         try:
-            i = int(input())
+            i = int(input()) if len(sys.argv) < 2 or len(remaining_args) == 0 else int(remaining_args.pop(0))
             if (i < first_option) or (i > last_option):
                 print(error_msg)
+                if (sys.argv > 1):
+                    sys.exit(1)
             else:
                 break
         except:
             print(error_msg)
+            if (sys.argv > 1):
+                sys.exit(1)
     return i
 
 def get_build_id() -> int:


### PR DESCRIPTION
While using the toolchain, I developed the need to interact with it from the command line. This PR allows a user to pass a list of numbers as command line arguments, representing a list of options to select in sequence, rather than manually typing numbers into the program to select each option one-by-one.
