### PR TITLE
Fix macOS/Linux (DETACHED_PROCESS issue) and remove unneccessary "PCSX-Redux.app"

### DIFF
--- a/tools/mod-builder/redux.py
+++ b/tools/mod-builder/redux.py
@@ -6,12 +6,14 @@ from clut import get_clut_list
 from game_options import game_options
 
 import os
-from subprocess import Popen, DETACHED_PROCESS
+from subprocess import Popen
+if os.name == "nt":
+    from subprocess import DETACHED_PROCESS
 
 import json
 import requests as r
 
-REDUX_EXES = ["pcsx-redux", "pcsx-redux.exe", "PCSX-Redux.app"]
+REDUX_EXES = ["pcsx-redux", "pcsx-redux.exe"]
 
 class Redux:
     def __init__(self) -> None:
@@ -66,7 +68,7 @@ class Redux:
                 print("\n[Redux-py] WARNING: game file not found at " + game_path)
                 print("PCSX-Redux will start without booting the iso.")
         os.chdir(self.path)
-        Popen(self.command + " -run -loadiso " + game_path, shell=True, start_new_session=True, close_fds=True, creationflags=DETACHED_PROCESS)
+        Popen(self.command + " -run -loadiso " + game_path, shell=True, start_new_session=True, close_fds=True, creationflags=DETACHED_PROCESS if os.name == "nt" else 0)
         os.chdir(curr_dir)
         self.load_map(warnings=False)
 


### PR DESCRIPTION
On Mac/Linux, the toolchain currently crashes immediately because redux.py imports DETACHED_PROCESS, which is not supported. I made the import and usage of DETACHED_PROCESS conditional on the OS. 

Also, I noticed that the program attempts to use PCSX-Redux.app as a potential executable name. However, on MacOS, a .app file is actually just a folder which contains the executable and other metadata within it. Therefore, checking for PCSX-Redux.app is invalid and just "pcsx-redux" is sufficient (this is the name of the actual executable that resides in the folder, same name as on linux).