### PR TITLE
Fixed incorrect cop2 argument in gte_gpl0 macro

### DIFF
--- a/tools/nugget/common/macros/gte.h
+++ b/tools/nugget/common/macros/gte.h
@@ -883,7 +883,7 @@
     __asm__ volatile( \
         "nop;"        \
         "nop;"        \
-        "cop2 0x01A0003E0")
+        "cop2 0x01A0003E")
 
 #define gte_mvmva_core(r0) \
     __asm__ volatile(      \


### PR DESCRIPTION
Trying to use the macro gte_gpl0 causes an out of range error during compilation. I checked the value, and it appears to have an extra zero at the end.