### PR TITLE
updated to accept game version param

### DIFF
--- a/tools/startup/plugin.py
+++ b/tools/startup/plugin.py
@@ -1,5 +1,5 @@
-def extract(plugin_path: str, game_path: str) -> None:
+def extract(plugin_path: str, game_path: str, game_version: str) -> None:
     pass
 
-def build(plugin_path: str, game_path: str) -> None:
+def build(plugin_path: str, game_path: str, game_version: str) -> None:
     pass


### PR DESCRIPTION
The base version of plugin.py generates an error since it only takes 2 params:

```build() takes 2 positional arguments but 3 were given```