### PR TITLE
Added NoReload specifier + skips adding New File + Minor Fixes

### DIFF
--- a/docs/2_developing.md
+++ b/docs/2_developing.md
@@ -105,6 +105,7 @@ version, section, address, offset, path, binary name [optional]
 Fields:
 ```
 version: set this to one of your versions defined in config.json, or use the special word "common" to apply to all versions. This line will only be compiled if it matches the version you selected to compile.
+you can also specify 'noreload' after the version to skip reloading the code while using the hot-reload feature.
 section: name of the section defined in disc.json which will be used to overwrite the data in the disc. You can leave this section empty if you want to add a new file to the disc.
 address: address which the binary will be compiled to. It can either be a decimal number, a hexadecimal number, or a symbol.
 offset: an offset which will be applied to the address. This field can be any valid python arithmetic expression.

--- a/games/Example_MegaManX4/mods/DebugTools/buildlist.txt
+++ b/games/Example_MegaManX4/mods/DebugTools/buildlist.txt
@@ -1,7 +1,7 @@
 
 //North American Version
 
-american, exe, 0x80026648, 0x0, src/background.c
+american NORELOAD , exe, 0x80026648, 0x0, src/background.c
 
 american, exe, 0x80020040, 0x0, src/menuHook.s
 american, exe, 0x800ee558, 0x0, src/debugmenu.c src/exception.c , DEBUG_AND_EXCEPTION.bin

--- a/tools/mod-builder/compile_list.py
+++ b/tools/mod-builder/compile_list.py
@@ -31,6 +31,7 @@ class CompileList:
         self.sym = sym
         self.prefix = prefix # path prefix
         self.ignore = False
+        self.skip_reload = False
         self.is_bin = False
         self.path_build_list = None
         self.source = None
@@ -80,7 +81,13 @@ class CompileList:
             self.ignore = True
             return
 
-        version = list_tokens[0]
+        version_str = list_tokens[0].replace("  "," ").split(" ")
+        version = version_str[0]
+
+        if len(version_str) > 1:
+            if version_str[1].lower() == "noreload":
+                self.skip_reload = True
+
         if is_number(version):
             version = int(version, 0)
             if version != self.sym.get_build_id():

--- a/tools/mod-builder/makefile.py
+++ b/tools/mod-builder/makefile.py
@@ -199,7 +199,8 @@ class Makefile:
             with open(COMP_SOURCE, "r") as file:
                 for line in file:
                     line = [l.strip() for l in line.split()]
-                    shutil.move(line[0], line[1])
+                    if _files.check_file(line[0]):
+                        shutil.move(line[0], line[1])
 
     def make(self) -> bool:
         """

--- a/tools/mod-builder/redux.py
+++ b/tools/mod-builder/redux.py
@@ -200,7 +200,7 @@ class Redux:
             with open(build_list, "r") as file:
                 for line in file:
                     cl = CompileList(line, sym, prefix)
-                    if not cl.should_build():
+                    if not cl.should_build() or cl.skip_reload:
                         continue
                     bin = cl.get_output_name() # pathlib object
                     backup_bin = pathlib.Path(prefix) / BACKUP_FOLDER / ("redux_" + cl.section_name + ".bin")


### PR DESCRIPTION
you can skip hot-reloading text by putting `noreload` after the version. I go rid of the code that creates a new file if the section doesnt exits and lastly , some minor fixes that I cant really remember.